### PR TITLE
Simplify CI workflow for Github Pages, remove redundant deployment steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,20 +1,28 @@
-name: Deploy to GitHub Pages
+name: CI
 
 on:
   push:
-    branches: [main]
+    branches: 
+      - main
+      - develop
   pull_request:
-    branches: [main]
+    branches: 
+      - main
+      - develop
 
 jobs:
-  build-and-deploy:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./
+      - name: Validate HTML
+        run: |
+          echo "Add HTML validation steps here"
+          # Future: Add html5validator or similar tool
+
+      - name: Check Links
+        run: |
+          echo "Add link checking steps here"
+          # Future: Add link checker


### PR DESCRIPTION
## Overview
This PR simplifies our GitHub Actions workflow by removing redundant deployment steps and focusing on CI checks. Since our repository is named `agentopia.github.io`, GitHub Pages automatically handles deployment from the `main` branch.

## Changes
- Renamed workflow from "Deploy to GitHub Pages" to "CI"
- Removed unnecessary deployment steps and permissions
- Added placeholders for future CI checks:
  - HTML validation
  - Link checking

## Why These Changes?
1. **Automatic Deployment**: 
   - For `<organization>.github.io` repositories, GitHub automatically publishes from the `main` branch
   - No additional deployment action is needed
   - Previous deployment workflow was redundant and could potentially conflict

2. **Focus on Quality**:
   - Shifted focus to CI checks
   - Added structure for future validation steps
   - Maintains checks for both `main` and `develop` branches

## Testing
- [ ] CI workflow triggers on PR
- [ ] CI workflow triggers on push to main/develop
- [ ] GitHub Pages continues to deploy automatically from main
- [ ] Placeholder steps execute successfully

## Next Steps
After merging, we can:
1. Implement actual HTML validation
2. Add link checking functionality
3. Consider additional CI checks as needed