### PR TITLE
Add issue template configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Community Support
+    url: https://github.com/orgs/community/discussions
+    about: Please ask and answer questions here.


### PR DESCRIPTION
## Overview
Add configuration file for issue templates to ensure they appear correctly in the GitHub interface.

## Changes
- Added [.github/ISSUE_TEMPLATE/config.yml]
- Disabled blank issues
- Added link to GitHub Community Support

## Testing
- [ ] Verify issue templates appear when creating new issues
- [ ] Test that all template options are available