### PR TITLE
Fix Issue Template Configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
-  - name: GitHub Community Support
-    url: https://github.com/orgs/community/discussions
+  - name: Questions & Discussions
+    url: https://github.com/Agentopia/agentopia.github.io/discussions
     about: Please ask and answer questions here.


### PR DESCRIPTION
## Overview
Update issue template configuration to ensure templates are properly displayed and accessible.

## Changes
- Enable blank issues (`blank_issues_enabled: true`)
- Update discussion link to point to our repository's discussions
- Improve template discoverability

## Before
Templates were not appearing in the "New Issue" interface.

## After
Templates should now appear with "Get started" buttons for:
- Feature Request
- Bug Report
- Documentation Update

## Testing
- [ ] Go to Issues > New Issue
- [ ] Verify all three templates are visible
- [ ] Verify "Get started" buttons appear
- [ ] Test creating an issue with each template

## Technical Details
Modified [.github/ISSUE_TEMPLATE/config.yml]
```yaml
blank_issues_enabled: true
contact_links:
  - name: Questions & Discussions
    url: https://github.com/Agentopia/agentopia.github.io/discussions
    about: Please ask and answer questions here.